### PR TITLE
Replace NodeSource Node.js install with binary download

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An Ansible role for installing Node.js.
 
 ## Role Variables
 
-- `nodejs_version` - Node.js version
+- `nodejs_version` - Node.js version (default: `0.10.32`)
+- `nodejs_os` - Node.js operating system build (default: `linux`)
+- `nodejs_arch`: Node.js architecture build (default: `x64`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
-nodejs_version: "0.10.32-1nodesource1~trusty1"
+nodejs_version: "0.10.32"
+nodejs_os: linux
+nodejs_arch: x64

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,20 @@
 ---
-- name: Configure the NodeSource APT key
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+- name: Download Node.js
+  get_url: >
+    url=http://nodejs.org/dist/v{{ nodejs_version }}/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}.tar.gz
+    dest=/usr/local/src/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}.tar.gz
 
-- name: Configure the NodeSource APT repositories
-  apt_repository: repo="deb https://deb.nodesource.com/node {{ ansible_distribution_release }} main"
-                  state=present
+- name: Extract and install Node.js
+  unarchive: src=/usr/local/src/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}.tar.gz
+             dest=/usr/local
+             copy=no
+             creates=/usr/local/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}
 
-- name: Install Node.js
-  apt: pkg=nodejs={{ nodejs_version }} state=present
+- name: Symlink Node.js into /usr/local/bin
+  file: >
+    src=/usr/local/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}/bin/{{ item }}
+    dest=/usr/local/bin/{{ item }}
+    state=link
+  with_items:
+    - node
+    - npm


### PR DESCRIPTION
The NodeSource repository was removing old versions of Node.js and replacing it with new versions. This made it difficult (impossible?) to pin installs to a specific version of Node.js. This changeset attempts to remedy that by downloading and installing  Node.js binaries directly from nodejs.org.
