### PR TITLE
Supply the full path to NPM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An Ansible role for installing Node.js.
 - `nodejs_os` - Node.js operating system build (default: `linux`)
 - `nodejs_arch`: Node.js architecture build (default: `x64`)
 - `nodejs_npm_version`: npm version (default: `1.4.28`)
+- `nodejs_symlink_path`: symlink path for node and npm (default: `/usr/local/bin`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ nodejs_version: "0.10.32"
 nodejs_os: linux
 nodejs_arch: x64
 nodejs_npm_version: 1.4.28
+nodejs_symlink_path: "/usr/local/bin"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,14 @@
 - name: Symlink Node.js into /usr/local/bin
   file: >
     src=/usr/local/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}/bin/{{ item }}
-    dest=/usr/local/bin/{{ item }}
+    dest={{ nodejs_symlink_path }}/{{ item }}
     state=link
   with_items:
     - node
     - npm
 
 - name: Determine what version of NPM is installed
-  command: npm --version
+  command: "{{ nodejs_symlink_path }}/npm --version"
   register: installed_npm_version
 
 - name: Upgrade NPM


### PR DESCRIPTION
In some environments, running npm without the full path results in failures.
This addresses the issue by supplying the full path to the binary.
